### PR TITLE
[renderer] Fix topic generation after recording interruption

### DIFF
--- a/src/renderer/views/discussion/DiscussionSegment.tsx
+++ b/src/renderer/views/discussion/DiscussionSegment.tsx
@@ -150,18 +150,12 @@ export function mergeUpMinutesText(
 
 /**
  * OpenAI API から取得した Segment を DiscussionSegment に変換して追加する
- * @param newSegments
- * @param minutes
- * @param limitSec
- * @param autoSplitDuration
- * @returns
  */
 export function appendMinutesList(
   newSegments: Segment[],
-  minutes: DiscussionSegment[],
   limitSec: number = 5
 ): DiscussionSegment[] {
-  let result: DiscussionSegment[] = [...minutes];
+  let result: DiscussionSegment[] = [];
   newSegments.map((newSegment) => {
     result = _appendMinutes(newSegment, result, limitSec);
   });
@@ -173,7 +167,7 @@ function _appendMinutes(
   minutes: DiscussionSegment[],
   limitSec: number
 ): DiscussionSegment[] {
-  //console.log("_appendMinutes: 0", minutes);
+  console.log("_appendMinutes: 0", minutes);
   let result: DiscussionSegment[] = minutes;
   if (newSegment.timestamp != undefined && newSegment.texts != undefined) {
     result = [...minutes];
@@ -250,7 +244,7 @@ function _appendMinutes(
       result.push(..._splitEndedTextsToSegment(target));
     }
   }
-  //console.log("_appendMinutes", result);
+  console.log("_appendMinutes", result);
   return result;
 }
 

--- a/src/renderer/views/store/useTranscribeStore.tsx
+++ b/src/renderer/views/store/useTranscribeStore.tsx
@@ -193,10 +193,10 @@ function setMinutesLines(segments: Segment[]) {
     useVBStore.getState().startTimestamp
   ).getState();
   const newMinutes = splitMinutes(
-    appendMinutesList(segments, minutesStore.discussion, 5),
+    appendMinutesList(segments, 5),
     minutesStore.discussionSplitter.duration
   );
-  //console.log("setMinutesLines", newMinutes, segments);
+  console.log("setMinutesLines", newMinutes, segments);
   processVBAction({
     type: "setMinutesLines",
     payload: {


### PR DESCRIPTION
Recording interruption and resumption previously caused already generated topics to be created again. This update resolves the issue by ensuring that only new topics are generated upon resuming recording.

Fixes #14