### PR TITLE
Fix Python command execution for virtual environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This Transcriber uses [Google Speech to Text](https://cloud.google.com/speech-to
 This is a Transcriber that leverages [voibo/mlx_whisper_stream](https://github.com/voibo/mlx_whisper_stream), a Python-based tool designed specifically for streaming speech recognition on macOS with Apple Silicon. No additional payment for transcribe is required!
 
 1. Set up [voibo/mlx_whisper_stream](https://github.com/voibo/mlx_whisper_stream) according to the README.md in the repository.
+   ❗ Make sure to use `venv` otherwise Voibo will not call the Python process properly.
 2. Enter the absolute path of the mlx_whisper_stream repository root directory (e.g., /Users/your_account/Document/GitHub/mlx_whisper_stream) in the Whisper Exec Path field.
 
 ### Keys

--- a/src/main/transcriber/localWhisper/WhisperTranscribeFromStream.ts
+++ b/src/main/transcriber/localWhisper/WhisperTranscribeFromStream.ts
@@ -1,6 +1,7 @@
 import { spawn, ChildProcessWithoutNullStreams } from "child_process";
 import { Readable } from "stream";
 import path from "path";
+import fs from "fs";
 import { IPCReceiverKeys, IPCSenderKeys } from "../../../common/constants.js";
 import { save } from "../../server-util.js";
 import { ITranscribeManager } from "../ITranscribeManager.js";
@@ -113,7 +114,17 @@ export class WhisperTranscribeFromStream {
 
     // Spawn the python process that uses Silero VAD + MLX Whisper
     const pythonScriptPath = this.pythonScriptPath;
-    this.pythonProcess = spawn(`${pythonScriptPath}/venv/bin/python3`, [
+    const venvPythonPath = `${pythonScriptPath}/venv/bin/python3`;
+    const pythonCommand = fs.existsSync(venvPythonPath)
+      ? venvPythonPath
+      : "python3";
+
+    console.log(
+      "Python command:",
+      pythonCommand,
+      `${pythonScriptPath}/mlx_whisper_stream.py`
+    );
+    this.pythonProcess = spawn(pythonCommand, [
       `${pythonScriptPath}/mlx_whisper_stream.py`,
     ]);
 


### PR DESCRIPTION
Ensure the application checks for a virtual environment before executing the Python command, improving compatibility and functionality. Update README to highlight the importance of using `venv`.